### PR TITLE
Changed DefaultUUIDs to be data classes

### DIFF
--- a/cobalt.core/src/jsMain/kotlin/org/hexworks/cobalt/core/internal/impl/DefaultUUID.kt
+++ b/cobalt.core/src/jsMain/kotlin/org/hexworks/cobalt/core/internal/impl/DefaultUUID.kt
@@ -4,27 +4,8 @@ import com.benasher44.uuid.Uuid
 import com.benasher44.uuid.uuid4
 import org.hexworks.cobalt.core.api.UUID
 
-class DefaultUUID(private val backend: Uuid = uuid4()) : UUID {
-
-    internal val uuid4 = uuid4()
-
-    override fun toString() = uuid4.toString()
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || this::class.js != other::class.js) return false
-
-        other as DefaultUUID
-
-        if (uuid4 != other.uuid4) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        return uuid4.hashCode()
-    }
-
-
-
+data class DefaultUUID(
+        private val backend: Uuid = uuid4()
+) : UUID {
+    override fun toString() = backend.toString()
 }

--- a/cobalt.core/src/jvmMain/kotlin/org/hexworks/cobalt/core/internal/impl/DefaultUUID.kt
+++ b/cobalt.core/src/jvmMain/kotlin/org/hexworks/cobalt/core/internal/impl/DefaultUUID.kt
@@ -2,26 +2,8 @@ package org.hexworks.cobalt.core.internal.impl
 
 import org.hexworks.cobalt.core.api.UUID
 
-class DefaultUUID(
-    private val backend: java.util.UUID = java.util.UUID.randomUUID()
+data class DefaultUUID(
+        private val backend: java.util.UUID = java.util.UUID.randomUUID()
 ) : UUID {
-
     override fun toString() = backend.toString()
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as DefaultUUID
-
-        if (backend != other.backend) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        return backend.hashCode()
-    }
-
-
 }


### PR DESCRIPTION
This change fixes an issue with js implementation where it wasn't delegating to its backend value, but rather another uuid instance that was created.

In terms of `equals` & `hashCode` it looks like the existing functions are doing what a data class does anyway so I decided to go with that.

As for `toString`, I've left these overrides in since data class' `toString` implementation would be of the "DefaultUuid(backend=...)"