### PR TITLE
Fixed an issue with disposeWhen and keepWhile

### DIFF
--- a/cobalt.core/src/commonMain/kotlin/org/hexworks/cobalt/core/behavior/Disposable.kt
+++ b/cobalt.core/src/commonMain/kotlin/org/hexworks/cobalt/core/behavior/Disposable.kt
@@ -35,7 +35,7 @@ interface Disposable {
             dispose()
         } else {
             var subscription: Subscription? = null
-            subscription = condition.onChange { (newValue) ->
+            subscription = condition.onChange { (_, newValue) ->
                 if (newValue) {
                     subscription?.dispose()
                     dispose()
@@ -53,7 +53,7 @@ interface Disposable {
             dispose()
         } else {
             var subscription: Subscription? = null
-            subscription = condition.onChange { (newValue) ->
+            subscription = condition.onChange { (_, newValue) ->
                 if (newValue.not()) {
                     subscription?.dispose()
                     dispose()


### PR DESCRIPTION
The destructured parameter was using the component1 as the newValue, but this is the oldValue. It now uses component2.