### PR TITLE
add support for IR compiler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - run:
           name: Execute Gradle
           command: |
-            ./gradlew build -x jsBrowserTest --no-daemon
+            ./gradlew build -x jsIrBrowserTest -x jsLegacyBrowserTest --no-daemon
 
 workflows:
   version: 2

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,7 @@ version=2021.1.1-PREVIEW
 
 kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.mpp.stability.nowarn=true
+kotlin.js.compiler=both
 
 org.gradle.jvmargs=-Xmx3g -XX:MaxPermSize=1g
 org.gradle.parallel=true


### PR DESCRIPTION
KotlinJs is moving a new compiler, so libraries should be compiled in "both" mode to produce artifacts for both legacy and IR compilers. See here for more info: https://kotlinlang.org/docs/js-ir-compiler.html#authoring-libraries-for-the-ir-compiler-with-backwards-compatibility

All the tests are passing, and I don't think any publishing stuff will need to be changed.